### PR TITLE
Support for milliseconds

### DIFF
--- a/src/main/kotlin/khronos/DateExtensions.kt
+++ b/src/main/kotlin/khronos/DateExtensions.kt
@@ -21,7 +21,7 @@ operator fun Date.minus(duration: Duration): Date {
 
 operator fun Date.rangeTo(other: Date) = DateRange(this, other)
 
-fun Date.with(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, minute: Int = -1, second: Int = -1): Date {
+fun Date.with(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, minute: Int = -1, second: Int = -1, millisecond: Int = -1): Date {
     calendar.time = this
     if (year > -1) calendar.set(Calendar.YEAR, year)
     if (month > -1) calendar.set(Calendar.MONTH, month - 1)
@@ -29,6 +29,7 @@ fun Date.with(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, mi
     if (hour > -1) calendar.set(Calendar.HOUR, hour)
     if (minute > -1) calendar.set(Calendar.MINUTE, minute)
     if (second > -1) calendar.set(Calendar.SECOND, second)
+    if (millisecond > -1) calendar.set(Calendar.MILLISECOND, millisecond)
     return calendar.time
 }
 
@@ -39,13 +40,13 @@ fun Date.with(weekday: Int = -1): Date {
 }
 
 val Date.beginningOfYear: Date
-    get() = with(month = 1, day = 1, hour = 0, minute = 0, second = 0)
+    get() = with(month = 1, day = 1, hour = 0, minute = 0, second = 0, millisecond = 0)
 
 val Date.endOfYear: Date
-    get() = with(month = 12, day = 31, hour = 23, minute = 59, second = 59)
+    get() = with(month = 12, day = 31, hour = 23, minute = 59, second = 59, millisecond = 999)
 
 val Date.beginningOfMonth: Date
-    get() = with(day = 1, hour = 0, minute = 0, second = 0)
+    get() = with(day = 1, hour = 0, minute = 0, second = 0, millisecond = 0)
 
 val Date.endOfMonth: Date
     get() = endOfMonth()
@@ -53,26 +54,26 @@ val Date.endOfMonth: Date
 fun Date.endOfMonth(): Date {
     calendar.time = this
     val lastDay = calendar.getActualMaximum(Calendar.DATE)
-    return with(day = lastDay, hour = 23, minute = 59, second = 59)
+    return with(day = lastDay, hour = 23, minute = 59, second = 59, millisecond = 999)
 }
 
 val Date.beginningOfDay: Date
-    get() = with(hour = 0, minute = 0, second = 0)
+    get() = with(hour = 0, minute = 0, second = 0, millisecond = 0)
 
 val Date.endOfDay: Date
-    get() = with(hour = 23, minute = 59, second = 59)
+    get() = with(hour = 23, minute = 59, second = 59, millisecond = 999)
 
 val Date.beginningOfHour: Date
-    get() = with(minute = 0, second = 0)
+    get() = with(minute = 0, second = 0, millisecond = 0)
 
 val Date.endOfHour: Date
-    get() = with(minute = 59, second = 59)
+    get() = with(minute = 59, second = 59, millisecond = 999)
 
 val Date.beginningOfMinute: Date
-    get() = with(second = 0)
+    get() = with(second = 0, millisecond = 0)
 
 val Date.endOfMinute: Date
-    get() = with(second = 59)
+    get() = with(second = 59, millisecond = 999)
 
 fun Date.toString(format: String) = SimpleDateFormat(format).format(this)
 

--- a/src/main/kotlin/khronos/Dates.kt
+++ b/src/main/kotlin/khronos/Dates.kt
@@ -21,7 +21,7 @@ object Dates {
         return calendar.time
     }
 
-    fun of(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, minute: Int = -1, second: Int = -1): Date {
+    fun of(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, minute: Int = -1, second: Int = -1, millisecond: Int = -1): Date {
         calendar.time = Date()
         if (year > -1) calendar.set(Calendar.YEAR, year)
         if (month > -1) calendar.set(Calendar.MONTH, month - 1)
@@ -29,6 +29,7 @@ object Dates {
         if (hour > -1) calendar.set(Calendar.HOUR, hour)
         if (minute > -1) calendar.set(Calendar.MINUTE, minute)
         if (second > -1) calendar.set(Calendar.SECOND, second)
+        if (millisecond > -1) calendar.set(Calendar.MILLISECOND, millisecond)
         return calendar.time
     }
 

--- a/src/main/kotlin/khronos/IntExtensions.kt
+++ b/src/main/kotlin/khronos/IntExtensions.kt
@@ -43,3 +43,9 @@ val Int.second: Duration
 
 val Int.seconds: Duration
     get() = second
+
+val Int.millisecond: Duration
+    get() = Duration(unit = Calendar.MILLISECOND, value = this)
+
+val Int.milliseconds: Duration
+    get() = millisecond

--- a/src/test/kotlin/khronos/DateExtensionsTest.kt
+++ b/src/test/kotlin/khronos/DateExtensionsTest.kt
@@ -49,7 +49,7 @@ class DateExtensionsTest {
     @Test fun endOfYear() {
         val date = Dates.of(year = 1987, month = 6, day = 2, hour = 5, minute = 0, second = 0)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 12, day = 31, hour = 23, minute = 59, second = 59),
+                expected = Dates.of(year = 1987, month = 12, day = 31, hour = 23, minute = 59, second = 59, millisecond = 999),
                 actual = date.endOfYear)
     }
 
@@ -63,7 +63,7 @@ class DateExtensionsTest {
     @Test fun endOfMonth() {
         val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 30, hour = 11, minute = 59, second = 59),
+                expected = Dates.of(year = 1987, month = 6, day = 30, hour = 11, minute = 59, second = 59, millisecond = 999),
                 actual = date.endOfMonth)
     }
 
@@ -77,7 +77,7 @@ class DateExtensionsTest {
     @Test fun endOfDay() {
         val date = Dates.of(year = 1987, month = 6, day = 2, hour = 9, minute = 0, second = 0)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 23, minute = 59, second = 59),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 23, minute = 59, second = 59, millisecond = 999),
                 actual = date.endOfDay)
     }
 
@@ -91,7 +91,7 @@ class DateExtensionsTest {
     @Test fun endOfHour() {
         val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 30)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 59, second = 59),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 59, second = 59, millisecond = 999),
                 actual = date.endOfHour)
     }
 
@@ -105,7 +105,7 @@ class DateExtensionsTest {
     @Test fun endOfMinute() {
         val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 30)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 59),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 59, millisecond = 999),
                 actual = date.endOfMinute)
     }
 

--- a/src/test/kotlin/khronos/IntExtensionsTest.kt
+++ b/src/test/kotlin/khronos/IntExtensionsTest.kt
@@ -64,4 +64,12 @@ class IntExtensionsTest {
         assertEquals(expected = Duration(unit = Calendar.SECOND, value = 15), actual = 15.seconds)
     }
 
+    @Test fun millisecond() {
+        assertEquals(expected = Duration(unit = Calendar.MILLISECOND, value = 1), actual = 1.millisecond)
+    }
+
+    @Test fun milliseconds() {
+        assertEquals(expected = Duration(unit = Calendar.MILLISECOND, value = 15), actual = 15.milliseconds)
+    }
+
 }

--- a/src/test/kotlin/khronos/StringExtensionsTest.kt
+++ b/src/test/kotlin/khronos/StringExtensionsTest.kt
@@ -9,7 +9,7 @@ class StringExtensionsTest {
 
     @Test fun toDate() {
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0, millisecond = 0),
                 actual = "1987-06-02".toDate("yyyy-MM-dd"))
     }
 


### PR DESCRIPTION
Add support for setting milliseconds, as epoch time in Java based on millis and not on seconds.

@hotchemi The unit tests works on my machine, do you have any idea why they fail?
