### PR TITLE
Changes to better reflect Java Calendar API

### DIFF
--- a/src/main/kotlin/khronos/DateExtensions.kt
+++ b/src/main/kotlin/khronos/DateExtensions.kt
@@ -24,9 +24,9 @@ operator fun Date.rangeTo(other: Date) = DateRange(this, other)
 fun Date.with(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, minute: Int = -1, second: Int = -1): Date {
     calendar.time = this
     if (year > -1) calendar.set(Calendar.YEAR, year)
-    if (month > -1) calendar.set(Calendar.MONTH, month - 1)
-    if (day > -1) calendar.set(Calendar.DATE, day - 1)
-    if (hour > -1) calendar.set(Calendar.HOUR, hour)
+    if (month > 0) calendar.set(Calendar.MONTH, month - 1)
+    if (day > 0) calendar.set(Calendar.DATE, day)
+    if (hour > -1) calendar.set(Calendar.HOUR_OF_DAY, hour)
     if (minute > -1) calendar.set(Calendar.MINUTE, minute)
     if (second > -1) calendar.set(Calendar.SECOND, second)
     return calendar.time

--- a/src/main/kotlin/khronos/Dates.kt
+++ b/src/main/kotlin/khronos/Dates.kt
@@ -17,16 +17,16 @@ object Dates {
 
     private fun setDate(value: Int): Date {
         calendar.time = Date()
-        calendar.add(Calendar.DATE, value);
+        calendar.add(Calendar.DATE, value)
         return calendar.time
     }
 
     fun of(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, minute: Int = -1, second: Int = -1): Date {
         calendar.time = Date()
         if (year > -1) calendar.set(Calendar.YEAR, year)
-        if (month > -1) calendar.set(Calendar.MONTH, month - 1)
-        if (day > -1) calendar.set(Calendar.DATE, day - 1)
-        if (hour > -1) calendar.set(Calendar.HOUR, hour)
+        if (month >  0) calendar.set(Calendar.MONTH, month - 1)
+        if (day > 0) calendar.set(Calendar.DATE, day)
+        if (hour > -1) calendar.set(Calendar.HOUR_OF_DAY, hour)
         if (minute > -1) calendar.set(Calendar.MINUTE, minute)
         if (second > -1) calendar.set(Calendar.SECOND, second)
         return calendar.time

--- a/src/main/kotlin/khronos/IntExtensions.kt
+++ b/src/main/kotlin/khronos/IntExtensions.kt
@@ -27,7 +27,7 @@ val Int.days: Duration
     get() = day
 
 val Int.hour: Duration
-    get() = Duration(unit = Calendar.HOUR, value = this)
+    get() = Duration(unit = Calendar.HOUR_OF_DAY, value = this)
 
 val Int.hours: Duration
     get() = hour

--- a/src/test/kotlin/khronos/DateExtensionsTest.kt
+++ b/src/test/kotlin/khronos/DateExtensionsTest.kt
@@ -63,14 +63,14 @@ class DateExtensionsTest {
     @Test fun endOfMonth() {
         val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 30, hour = 11, minute = 59, second = 59),
+                expected = Dates.of(year = 1987, month = 6, day = 30, hour = 23, minute = 59, second = 59),
                 actual = date.endOfMonth)
     }
 
     @Test fun beginningOfDay() {
         val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 0, minute = 0, second = 0),
                 actual = date.beginningOfDay)
     }
 
@@ -110,7 +110,7 @@ class DateExtensionsTest {
     }
 
     @Test fun to_String() {
-        val calendar= Calendar.getInstance()
+        val calendar = Calendar.getInstance()
         calendar.set(Calendar.MINUTE, calendar.get(Calendar.MINUTE) + 5)
         Assert.assertEquals(
                 SimpleDateFormat("yyyy-MM-dd HH").format(calendar.time),

--- a/src/test/kotlin/khronos/DatesTest.kt
+++ b/src/test/kotlin/khronos/DatesTest.kt
@@ -42,7 +42,7 @@ class DatesTest {
 
     @Test fun dateDay() {
         val calendar = Calendar.getInstance()
-        calendar.set(Calendar.DATE, 20)
+        calendar.set(Calendar.DATE, 21)
         assertEquals(expected = calendar.time, actual = Dates.of(day = 21))
     }
 

--- a/src/test/kotlin/khronos/DatesTest.kt
+++ b/src/test/kotlin/khronos/DatesTest.kt
@@ -48,7 +48,7 @@ class DatesTest {
 
     @Test fun dateHour() {
         val calendar = Calendar.getInstance()
-        calendar.set(Calendar.HOUR, 4)
+        calendar.set(Calendar.HOUR_OF_DAY, 4)
         assertEquals(expected = calendar.time, actual = Dates.of(hour = 4))
     }
 

--- a/src/test/kotlin/khronos/IntExtensionsTest.kt
+++ b/src/test/kotlin/khronos/IntExtensionsTest.kt
@@ -41,11 +41,11 @@ class IntExtensionsTest {
     }
 
     @Test fun hour() {
-        assertEquals(expected = Duration(unit = Calendar.HOUR, value = 1), actual = 1.hour)
+        assertEquals(expected = Duration(unit = Calendar.HOUR_OF_DAY, value = 1), actual = 1.hour)
     }
 
     @Test fun hours() {
-        assertEquals(expected = Duration(unit = Calendar.HOUR, value = 11), actual = 11.hours)
+        assertEquals(expected = Duration(unit = Calendar.HOUR_OF_DAY, value = 11), actual = 11.hours)
     }
 
     @Test fun minute() {

--- a/src/test/kotlin/khronos/StringExtensionsTest.kt
+++ b/src/test/kotlin/khronos/StringExtensionsTest.kt
@@ -9,7 +9,7 @@ class StringExtensionsTest {
 
     @Test fun toDate() {
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 0, minute = 0, second = 0),
                 actual = "1987-06-02".toDate("yyyy-MM-dd"))
     }
 


### PR DESCRIPTION
Changed to 24h API → use HOUR_OF_DAY
Changed DATE (DAY_OF_MONTH) to start at 1 (not zero based like month)
Fixed tests to reflect new api