### PR TITLE
Add support for milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+- 0.9.1
+  - Support Kotlin 1.1.51
+  - Add support for milliseconds
 - 0.9.0
   - Support Kotlin 1.1.2
   - Fix Fixed [DAY_OF_MONTH related bug](https://github.com/hotchemi/khronos/pull/15)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ val fiveYearsSince = 5.years.since
 
 ```kotlin
 val birthday = Dates.of(year = 1990, month = 1, day = 21)
-val firstCommitDate = Dates.of(year = 2016, month = 2, day = 26, hour = 18, minute = 58, second = 31)
+val firstCommitDate = Dates.of(year = 2016, month = 2, day = 26, hour = 18, minute = 58, second = 31, millisecond = 777)
 ```
 
 ### Initialize by changing date components

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.1.51'
     repositories {
         mavenCentral()
         jcenter()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 USER = hotchemi
 GROUP_ID = com.github.hotchemi
 ARTIFACT_ID = khronos
-VERSION = 0.9.0
+VERSION = 0.9.1
 DESCRIPTION = An intuitive Date extensions in Kotlin.
 WEBSITE = https://github.com/hotchemi/khronos
 LICENCES = ['Apache-2.0']

--- a/src/main/kotlin/khronos/DateExtensions.kt
+++ b/src/main/kotlin/khronos/DateExtensions.kt
@@ -21,7 +21,7 @@ operator fun Date.minus(duration: Duration): Date {
 
 operator fun Date.rangeTo(other: Date) = DateRange(this, other)
 
-fun Date.with(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, minute: Int = -1, second: Int = -1): Date {
+fun Date.with(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, minute: Int = -1, second: Int = -1, millisecond: Int = -1): Date {
     calendar.time = this
     if (year > -1) calendar.set(Calendar.YEAR, year)
     if (month > 0) calendar.set(Calendar.MONTH, month - 1)
@@ -29,6 +29,7 @@ fun Date.with(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, mi
     if (hour > -1) calendar.set(Calendar.HOUR_OF_DAY, hour)
     if (minute > -1) calendar.set(Calendar.MINUTE, minute)
     if (second > -1) calendar.set(Calendar.SECOND, second)
+    if (millisecond > -1) calendar.set(Calendar.MILLISECOND, millisecond)
     return calendar.time
 }
 
@@ -39,13 +40,13 @@ fun Date.with(weekday: Int = -1): Date {
 }
 
 val Date.beginningOfYear: Date
-    get() = with(month = 1, day = 1, hour = 0, minute = 0, second = 0)
+    get() = with(month = 1, day = 1, hour = 0, minute = 0, second = 0, millisecond = 0)
 
 val Date.endOfYear: Date
-    get() = with(month = 12, day = 31, hour = 23, minute = 59, second = 59)
+    get() = with(month = 12, day = 31, hour = 23, minute = 59, second = 59, millisecond = 999)
 
 val Date.beginningOfMonth: Date
-    get() = with(day = 1, hour = 0, minute = 0, second = 0)
+    get() = with(day = 1, hour = 0, minute = 0, second = 0, millisecond = 0)
 
 val Date.endOfMonth: Date
     get() = endOfMonth()
@@ -53,26 +54,26 @@ val Date.endOfMonth: Date
 fun Date.endOfMonth(): Date {
     calendar.time = this
     val lastDay = calendar.getActualMaximum(Calendar.DATE)
-    return with(day = lastDay, hour = 23, minute = 59, second = 59)
+    return with(day = lastDay, hour = 23, minute = 59, second = 59, millisecond = 999)
 }
 
 val Date.beginningOfDay: Date
-    get() = with(hour = 0, minute = 0, second = 0)
+    get() = with(hour = 0, minute = 0, second = 0, millisecond = 0)
 
 val Date.endOfDay: Date
-    get() = with(hour = 23, minute = 59, second = 59)
+    get() = with(hour = 23, minute = 59, second = 59, millisecond = 999)
 
 val Date.beginningOfHour: Date
-    get() = with(minute = 0, second = 0)
+    get() = with(minute = 0, second = 0, millisecond = 0)
 
 val Date.endOfHour: Date
-    get() = with(minute = 59, second = 59)
+    get() = with(minute = 59, second = 59, millisecond = 999)
 
 val Date.beginningOfMinute: Date
-    get() = with(second = 0)
+    get() = with(second = 0, millisecond = 0)
 
 val Date.endOfMinute: Date
-    get() = with(second = 59)
+    get() = with(second = 59, millisecond = 999)
 
 fun Date.toString(format: String): String = SimpleDateFormat(format).format(this)
 

--- a/src/main/kotlin/khronos/Dates.kt
+++ b/src/main/kotlin/khronos/Dates.kt
@@ -18,14 +18,7 @@ object Dates {
         return calendar.time
     }
 
-    fun of(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, minute: Int = -1, second: Int = -1): Date {
-        calendar.time = Date()
-        if (year > -1) calendar.set(Calendar.YEAR, year)
-        if (month >  0) calendar.set(Calendar.MONTH, month - 1)
-        if (day > 0) calendar.set(Calendar.DATE, day)
-        if (hour > -1) calendar.set(Calendar.HOUR_OF_DAY, hour)
-        if (minute > -1) calendar.set(Calendar.MINUTE, minute)
-        if (second > -1) calendar.set(Calendar.SECOND, second)
-        return calendar.time
+    fun of(year: Int = -1, month: Int = -1, day: Int = -1, hour: Int = -1, minute: Int = -1, second: Int = -1, millisecond: Int = -1): Date {
+        return Date().with(year, month, day, hour, minute, second, millisecond)
     }
 }

--- a/src/main/kotlin/khronos/IntExtensions.kt
+++ b/src/main/kotlin/khronos/IntExtensions.kt
@@ -43,3 +43,9 @@ val Int.second: Duration
 
 val Int.seconds: Duration
     get() = second
+
+val Int.millisecond: Duration
+    get() = Duration(unit = Calendar.MILLISECOND, value = this)
+
+val Int.milliseconds: Duration
+    get() = millisecond

--- a/src/test/kotlin/khronos/DateExtensionsTest.kt
+++ b/src/test/kotlin/khronos/DateExtensionsTest.kt
@@ -9,103 +9,108 @@ import java.util.*
  * Unit test for DateExtensions.kt.
  */
 class DateExtensionsTest {
+    companion object {
+        val iso8601 = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS")
+    }
 
     @Test fun plus() {
-        val calendar = Calendar.getInstance()
-        calendar.add(Calendar.WEEK_OF_MONTH, 1)
-        val nextWeek = calendar.time
-        assertEquals(expected = nextWeek, actual = Dates.today + 1.week)
+        val date = iso8601.parse("2017-10-21T13:05:20.632")
+        assertEquals(
+            expected = iso8601.parse("2017-10-28T15:05:20.632"),
+            actual = date + 1.week + 2.hours
+        )
     }
 
     @Test fun minus() {
-        val calendar = Calendar.getInstance()
-        calendar.add(Calendar.DAY_OF_MONTH, -2)
-        val dayBeforeYesterday = calendar.time
-        assertEquals(expected = dayBeforeYesterday, actual = Dates.today - 2.days)
+        val date = iso8601.parse("2017-10-21T13:05:20.632")
+        assertEquals(
+            expected = iso8601.parse("2017-10-20T13:05:19.999"),
+            actual = date - 1.day - 633.milliseconds
+        )
     }
 
     @Test fun with() {
         run {
-            val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0)
+            val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 4, second = 33, millisecond = 123)
             assertEquals(
-                    expected = Dates.of(year = 1990, month = 6, day = 2, hour = 12, minute = 0, second = 0),
+                    expected = Dates.of(year = 1990, month = 6, day = 2, hour = 12, minute = 4, second = 33, millisecond = 123),
                     actual = date.with(year = 1990))
         }
         run {
-            val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0)
+            val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 55, second = 1, millisecond = 321)
             assertEquals(
-                    expected = Dates.of(year = 1987, month = 6, day = 9, hour = 12, minute = 0, second = 0),
+                    expected = Dates.of(year = 1987, month = 6, day = 9, hour = 12, minute = 55, second = 1, millisecond = 321),
                     actual = date.with(weekday = 2))
         }
     }
 
     @Test fun beginningOfYear() {
-        val date = Dates.of(year = 2016, month = 6, day = 2, hour = 5, minute = 30, second = 0)
+        val date = Dates.of(year = 2016, month = 6, day = 2, hour = 5, minute = 30, second = 59, millisecond = 888)
         assertEquals(
-                expected = Dates.of(year = 2016, month = 1, day = 1, hour = 0, minute = 0, second = 0),
+                expected = Dates.of(year = 2016, month = 1, day = 1, hour = 0, minute = 0, second = 0, millisecond = 0),
                 actual = date.beginningOfYear)
     }
 
     @Test fun endOfYear() {
-        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 5, minute = 0, second = 0)
+        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 5, minute = 0, second = 0, millisecond = 101)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 12, day = 31, hour = 23, minute = 59, second = 59),
+                expected = Dates.of(year = 1987, month = 12, day = 31, hour = 23, minute = 59, second = 59, millisecond = 999),
                 actual = date.endOfYear)
     }
 
     @Test fun beginningOfMonth() {
-        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 5, minute = 0, second = 0)
+        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 5, minute = 0, second = 0, millisecond = 123)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 1, hour = 0, minute = 0, second = 0),
+                expected = Dates.of(year = 1987, month = 6, day = 1, hour = 0, minute = 0, second = 0, millisecond = 0),
                 actual = date.beginningOfMonth)
     }
 
     @Test fun endOfMonth() {
-        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0)
+        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0, millisecond = 0)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 30, hour = 23, minute = 59, second = 59),
+                expected = Dates.of(year = 1987, month = 6, day = 30, hour = 23, minute = 59, second = 59, millisecond = 999),
                 actual = date.endOfMonth)
     }
 
     @Test fun beginningOfDay() {
-        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0)
+        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0, millisecond = 12)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 0, minute = 0, second = 0),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 0, minute = 0, second = 0, millisecond = 0),
                 actual = date.beginningOfDay)
     }
 
     @Test fun endOfDay() {
-        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 9, minute = 0, second = 0)
+        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 9, minute = 0, second = 0, millisecond = 998)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 23, minute = 59, second = 59),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 23, minute = 59, second = 59, millisecond = 999),
                 actual = date.endOfDay)
     }
 
     @Test fun beginningOfHour() {
-        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 30)
+        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 30, millisecond = 1)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 0, second = 0, millisecond = 0),
                 actual = date.beginningOfHour)
     }
 
     @Test fun endOfHour() {
-        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 30)
+        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 30, millisecond = 58)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 59, second = 59),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 59, second = 59, millisecond = 999),
                 actual = date.endOfHour)
     }
 
     @Test fun beginningOfMinute() {
-        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 30)
+        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 30, millisecond = 2)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 0),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 0, millisecond = 0),
                 actual = date.beginningOfMinute)
     }
 
     @Test fun endOfMinute() {
-        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 30)
+        val date = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 30, millisecond = 54)
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 59),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 12, minute = 30, second = 59, millisecond = 999),
                 actual = date.endOfMinute)
     }
 

--- a/src/test/kotlin/khronos/DatesTest.kt
+++ b/src/test/kotlin/khronos/DatesTest.kt
@@ -9,59 +9,59 @@ import java.util.*
 class DatesTest {
 
     @Test fun now() {
-        assertEquals(expected = Date(), actual = Dates.today)
+        assertVeryClose(from = Date(), to = Dates.today)
     }
 
     @Test fun today() {
-        assertEquals(expected = Date(), actual = Dates.today)
+        assertVeryClose(from = Date(), to = Dates.today)
     }
 
     @Test fun tomorrow() {
         val calendar = Calendar.getInstance()
         calendar.add(Calendar.DAY_OF_MONTH, 1)
-        assertEquals(expected = calendar.time, actual = Dates.tomorrow)
+        assertVeryClose(from = calendar.time, to = Dates.tomorrow)
     }
 
     @Test fun yesterday() {
         val calendar = Calendar.getInstance()
         calendar.add(Calendar.DAY_OF_MONTH, -1)
-        assertEquals(expected = calendar.time, actual = Dates.yesterday)
+        assertVeryClose(from = calendar.time, to = Dates.yesterday)
     }
 
     @Test fun dateYear() {
         val calendar = Calendar.getInstance()
         calendar.set(Calendar.YEAR, 1990)
-        assertEquals(expected = calendar.time, actual = Dates.of(year = 1990))
+        assertVeryClose(from = calendar.time, to = Dates.of(year = 1990))
     }
 
     @Test fun dateMonth() {
         val calendar = Calendar.getInstance()
         calendar.set(Calendar.MONTH, 0)
-        assertEquals(expected = calendar.time, actual = Dates.of(month = 1))
+        assertVeryClose(from = calendar.time, to = Dates.of(month = 1))
     }
 
     @Test fun dateDay() {
         val calendar = Calendar.getInstance()
         calendar.set(Calendar.DATE, 21)
-        assertEquals(expected = calendar.time, actual = Dates.of(day = 21))
+        assertVeryClose(from = calendar.time, to = Dates.of(day = 21))
     }
 
     @Test fun dateHour() {
         val calendar = Calendar.getInstance()
         calendar.set(Calendar.HOUR_OF_DAY, 4)
-        assertEquals(expected = calendar.time, actual = Dates.of(hour = 4))
+        assertVeryClose(from = calendar.time, to = Dates.of(hour = 4))
     }
 
     @Test fun dateMinute() {
         val calendar = Calendar.getInstance()
         calendar.set(Calendar.MINUTE, 30)
-        assertEquals(expected = calendar.time, actual = Dates.of(minute = 30))
+        assertVeryClose(from = calendar.time, to = Dates.of(minute = 30))
     }
 
     @Test fun dateSecond() {
         val calendar = Calendar.getInstance()
         calendar.set(Calendar.SECOND, 10)
-        assertEquals(expected = calendar.time, actual = Dates.of(second = 10))
+        assertVeryClose(from = calendar.time, to = Dates.of(second = 10))
     }
 
 }

--- a/src/test/kotlin/khronos/IntExtensionsTest.kt
+++ b/src/test/kotlin/khronos/IntExtensionsTest.kt
@@ -64,4 +64,12 @@ class IntExtensionsTest {
         assertEquals(expected = Duration(unit = Calendar.SECOND, value = 15), actual = 15.seconds)
     }
 
+    @Test fun millisecond() {
+        assertEquals(expected = Duration(unit = Calendar.MILLISECOND, value = 1), actual = 1.millisecond)
+    }
+
+    @Test fun milliseconds() {
+        assertEquals(expected = Duration(unit = Calendar.MILLISECOND, value = 15), actual = 15.milliseconds)
+    }
+
 }

--- a/src/test/kotlin/khronos/StringExtensionsTest.kt
+++ b/src/test/kotlin/khronos/StringExtensionsTest.kt
@@ -9,7 +9,7 @@ class StringExtensionsTest {
 
     @Test fun toDate() {
         assertEquals(
-                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 0, minute = 0, second = 0),
+                expected = Dates.of(year = 1987, month = 6, day = 2, hour = 0, minute = 0, second = 0, millisecond = 0),
                 actual = "1987-06-02".toDate("yyyy-MM-dd"))
     }
 

--- a/src/test/kotlin/khronos/Utils.kt
+++ b/src/test/kotlin/khronos/Utils.kt
@@ -12,6 +12,12 @@ fun assertEquals(expected: Date, actual: Date) {
     Assert.assertEquals(iso8601.format(expected), iso8601.format(actual))
 }
 
+fun assertVeryClose(maxOffset: Int = 200, from: Date, to: Date) {
+    Assert.assertTrue(
+            String.format("There is more than %d ms between %s and %s", maxOffset, iso8601.format(from), iso8601.format(to)),
+            Math.abs(from.time - to.time) <= maxOffset)
+}
+
 fun assertEquals(expected: Duration, actual: Duration) {
     Assert.assertEquals(expected, actual)
 }

--- a/src/test/kotlin/khronos/Utils.kt
+++ b/src/test/kotlin/khronos/Utils.kt
@@ -1,10 +1,15 @@
 package khronos
 
 import org.junit.Assert
+import java.text.SimpleDateFormat
 import java.util.*
 
+internal val iso8601: SimpleDateFormat by lazy {
+    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS")
+}
+
 fun assertEquals(expected: Date, actual: Date) {
-    Assert.assertEquals(expected.toString(), actual.toString())
+    Assert.assertEquals(iso8601.format(expected), iso8601.format(actual))
 }
 
 fun assertEquals(expected: Duration, actual: Duration) {


### PR DESCRIPTION
Hi there!

Java `Date` are precise to milliseconds so I think it would be a good idea for this library to support milliseconds.

Otherwise, you don't have any way of creating two equal dates:
```kotlin
val date     = Dates.of(year = 2016, month = 2, day = 26, hour = 18, minute = 58, second = 31)
val sameDate = Dates.of(year = 2016, month = 2, day = 26, hour = 18, minute = 58, second = 31)
date.equals(sameDate) // => return false!
```

This PR allow this library to creates two equal dates:
```kotlin
val date     = Dates.of(year = 2016, month = 2, day = 26, hour = 18, minute = 58, second = 31, millisecond = 777)
val sameDate = Dates.of(year = 2016, month = 2, day = 26, hour = 18, minute = 58, second = 31, millisecond = 777)
date.equals(sameDate) // => return true
```

I think there is no breaking changes and all unit tests should pass.
Don't hesitate to ask me for changes, I really like this library but I need to compare dates equality so I need this changes :)