### PR TITLE
Subtracting a month does not work

### DIFF
--- a/src/main/kotlin/khronos/IntExtensions.kt
+++ b/src/main/kotlin/khronos/IntExtensions.kt
@@ -9,7 +9,7 @@ val Int.years: Duration
     get() = year
 
 val Int.month: Duration
-    get() = Duration(unit = Calendar.MONTH, value = this - 1)
+    get() = Duration(unit = Calendar.MONTH, value = this)
 
 val Int.months: Duration
     get() = month

--- a/src/test/kotlin/khronos/DurationTest.kt
+++ b/src/test/kotlin/khronos/DurationTest.kt
@@ -22,13 +22,15 @@ class DurationTest {
         assertEquals(expected = fiveYearsLater, actual = 5.years.since)
     }
 
-    @Test fun addMonth() {
+    /**Test that subtracting a month results in the correct change to the date.*/
+    @Test fun subtractMonth() {
         val n = Dates.today + 5.months
-        val dayNumber = n.dayWithCalendar()
-        val monthNumber = n.monthWithCalendar()
+        val dayNumber = n.dayByCalendar()
+        val monthNumber = n.monthByCalendar()
         val monthAgo = n - 1.month
-        assert(monthAgo.dayWithCalendar() == dayNumber)
-        assert(monthAgo.monthWithCalendar() + 1 == monthNumber)
+        assert(monthAgo.dayByCalendar() == dayNumber)
+        val delta = (if (monthNumber == 0) 11 else monthNumber - 1)
+        assert(monthAgo.monthByCalendar() == delta)
     }
 
 }

--- a/src/test/kotlin/khronos/DurationTest.kt
+++ b/src/test/kotlin/khronos/DurationTest.kt
@@ -22,4 +22,13 @@ class DurationTest {
         assertEquals(expected = fiveYearsLater, actual = 5.years.since)
     }
 
+    @Test fun addMonth() {
+        val n = Dates.today + 5.months
+        val dayNumber = n.dayWithCalendar()
+        val monthNumber = n.monthWithCalendar()
+        val monthAgo = n - 1.month
+        assert(monthAgo.dayWithCalendar() == dayNumber)
+        assert(monthAgo.monthWithCalendar() + 1 == monthNumber)
+    }
+
 }

--- a/src/test/kotlin/khronos/IntExtensionsTest.kt
+++ b/src/test/kotlin/khronos/IntExtensionsTest.kt
@@ -17,11 +17,11 @@ class IntExtensionsTest {
     }
 
     @Test fun month() {
-        assertEquals(expected = Duration(unit = Calendar.MONTH, value = 0), actual = 1.month)
+        assertEquals(expected = Duration(unit = Calendar.MONTH, value = 1), actual = 1.month)
     }
 
     @Test fun months() {
-        assertEquals(expected = Duration(unit = Calendar.MONTH, value = 2), actual = 3.months)
+        assertEquals(expected = Duration(unit = Calendar.MONTH, value = 3), actual = 3.months)
     }
 
     @Test fun week() {

--- a/src/test/kotlin/khronos/Utils.kt
+++ b/src/test/kotlin/khronos/Utils.kt
@@ -21,3 +21,15 @@ fun assertVeryClose(maxOffset: Int = 200, from: Date, to: Date) {
 fun assertEquals(expected: Duration, actual: Duration) {
     Assert.assertEquals(expected, actual)
 }
+
+fun Date.dayWithCalendar(): Int {
+    val calendar = Calendar.getInstance()
+    calendar.time = this
+    return calendar.get(Calendar.DAY_OF_MONTH)
+}
+
+fun Date.monthWithCalendar(): Int {
+    val calendar = Calendar.getInstance()
+    calendar.time = this
+    return calendar.get(Calendar.MONTH)
+}

--- a/src/test/kotlin/khronos/Utils.kt
+++ b/src/test/kotlin/khronos/Utils.kt
@@ -22,13 +22,15 @@ fun assertEquals(expected: Duration, actual: Duration) {
     Assert.assertEquals(expected, actual)
 }
 
-fun Date.dayWithCalendar(): Int {
+/**Returns the day of month for this date.*/
+fun Date.dayByCalendar(): Int {
     val calendar = Calendar.getInstance()
     calendar.time = this
     return calendar.get(Calendar.DAY_OF_MONTH)
 }
 
-fun Date.monthWithCalendar(): Int {
+/**Returns the month for this date.*/
+fun Date.monthByCalendar(): Int {
     val calendar = Calendar.getInstance()
     calendar.time = this
     return calendar.get(Calendar.MONTH)


### PR DESCRIPTION
#30 

This is a breaking change, but it is an improvement in terms of semantics. We should not take the 0-index ordering of months of the Java Date APIs as gospel here. `5.months` should _actually_ give us 5 months worth of duration to add to a Date.